### PR TITLE
LINARO: arm64: topology: fix cpu power calculation

### DIFF
--- a/arch/arm64/kernel/topology.c
+++ b/arch/arm64/kernel/topology.c
@@ -350,16 +350,12 @@ static void __init parse_dt_cpu_power(void)
 		cpu_capacity(cpu) = capacity;
 	}
 
-	/* If min and max capacities are equal we bypass the update of the
-	 * cpu_scale because all CPUs have the same capacity. Otherwise, we
-	 * compute a middle_capacity factor that will ensure that the capacity
+	/* compute a middle_capacity factor that will ensure that the capacity
 	 * of an 'average' CPU of the system will be as close as possible to
 	 * SCHED_CAPACITY_SCALE, which is the default value, but with the
 	 * constraint explained near table_efficiency[].
 	 */
-	if (min_capacity == max_capacity)
-		return;
-	else if (4 * max_capacity < (3 * (max_capacity + min_capacity)))
+	if (4 * max_capacity < (3 * (max_capacity + min_capacity)))
 		middle_capacity = (min_capacity + max_capacity)
 				>> (SCHED_CAPACITY_SHIFT+1);
 	else


### PR DESCRIPTION
From: https://git.linaro.org/kernel/linux-linaro-stable.git/commit/?id=646fe96c67a5fcc2cfffb7326b2299f2714f7f27

This commit sets the power of the average CPU in SMP systems to
SCHED_CAPACITY_SCALE.

Ignoring the condition "min_capacity==max_capacity" causes the function
update_cpu_power( .. ) to generate out of range values. This is
because the default value of middle_capacity is used in the final
calculation instead of a valid scaling factor.

Incidentally, when out of range values are generated and if
SCHED_FEAT(ARCH_POWER) is true, the load balancing algorithm makes
incorrect scheduling decisions typically overallocating all the work
on one of the CPU cores.

This proposed solution to arm64 is in line with the upstream solution
present in arm32 since the commit below was merged:

* SHA: 816a8de0017f16c32e747abc5367bf379515b20a
* From: Sudeep KarkadaNagesha <sudeep.karkadanagesha@arm.com>
* Date: Mon, 17 Jun 2013 14:20:00 +0100
* Subject: ARM: topology: remove hwid/MPIDR dependency from cpu_capac

Signed-off-by: Jorge Ramirez-Ortiz <jorge.ramirez-ortiz@linaro.org>
Acked-by: Vincent Guittot <vincent.guittot@linaro.org>
Signed-off-by: Kevin Hilman <khilman@linaro.org>
Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>